### PR TITLE
Delete original after successful encode + optional --status-port HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ python get_timelapse.py [options]
 - `--no-gpu`  
   Force CPU-only processing for video conversion (useful if you do not have an NVIDIA GPU; uses libx265 instead of hevc_nvenc).
 
+- `--status-port <port>`  
+  Expose an HTTP status endpoint on the given port. Useful with `--watch`
+  for external monitoring (Uptime Kuma, Prometheus blackbox, etc.).
+  Returns JSON `{state, last_check, last_success, last_error, current_file}`
+  where `state` is `starting | idle | working | error`. HTTP status is
+  **200** normally and **503** when the last cycle errored, so a plain
+  status-code monitor is sufficient (no JSON parsing required). Off by
+  default.
+
 ### Example Commands
 
 Download the latest timelapse and make it streamable (default):

--- a/get_timelapse.py
+++ b/get_timelapse.py
@@ -14,6 +14,61 @@ import asyncio
 import re
 import shutil
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+# --- Optional HTTP status endpoint (enable with --status-port) ---
+# Lets external monitoring (Uptime Kuma, Prometheus blackbox, etc.) probe
+# whether the watcher is healthy. Disabled unless --status-port is passed.
+
+_STATE_LOCK = threading.Lock()
+_STATE = {
+    "state": "starting",   # starting | idle | working | error
+    "last_check": None,    # ISO timestamp of last completed cycle
+    "last_success": None,  # ISO timestamp of last cycle without errors
+    "last_error": None,    # last error message
+    "current_file": None,  # name of file currently being processed
+}
+
+
+def _set_state(**kwargs):
+    with _STATE_LOCK:
+        _STATE.update(kwargs)
+
+
+def _now_iso():
+    return datetime.now().isoformat(timespec="seconds")
+
+
+class _StatusHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.rstrip("/") not in ("", "/status", "/health"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        with _STATE_LOCK:
+            snapshot = dict(_STATE)
+        body = json.dumps(snapshot).encode()
+        # 503 when the last cycle errored, so a plain HTTP status-code
+        # monitor is sufficient (no JSON parsing required).
+        code = 503 if snapshot["state"] == "error" else 200
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        # Suppress access logs — the monitoring poll would spam stdout.
+        pass
+
+
+def _start_status_server(port):
+    server = HTTPServer(("0.0.0.0", port), _StatusHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    print(f"Status server listening on :{port}")
+
 
 def check_ffmpeg_dependencies():
     """Check if ffmpeg and ffprobe are available in the system PATH."""
@@ -158,7 +213,11 @@ def main():
     parser.add_argument('--no-gpu', action='store_true', help='Force CPU-only processing (no NVIDIA GPU required)')
     parser.add_argument('--speed', type=float, default=0.3, help='Adjust video speed (e.g., 0.5 for half speed, 2.0 for double speed). Default is 0.3 (slower speed).')
     parser.add_argument('--test', action='store_true', help='Run test mode: process and upload test_video.avi')
+    parser.add_argument('--status-port', type=int, default=None, help='Expose an HTTP status endpoint on this port (returns JSON; 200 normally, 503 on error). Useful with --watch for external monitoring (Uptime Kuma, etc.).')
     args = parser.parse_args()
+
+    if args.status_port:
+        _start_status_server(args.status_port)
 
     # Test mode implementation
     if args.test:
@@ -231,6 +290,7 @@ def main():
     os.makedirs(out_dir, exist_ok=True)
 
     async def download_and_process():
+        _set_state(state="working", last_error=None)
         ftp = None
         try:
             ftp = ImplicitFTP_TLS()
@@ -241,10 +301,14 @@ def main():
                 ftp.login('bblp', ACCESS_CODE)
                 ftp.prot_p()
             except OSError as e:
-                print(f"Network error during FTP connection: {e}")
+                msg = f"Network error during FTP connection: {e}"
+                print(msg)
+                _set_state(state="error", last_error=msg, last_check=_now_iso())
                 return False
             except all_errors as ex:
-                print(f"FTP error during connection: {ex}")
+                msg = f"FTP error during connection: {ex}"
+                print(msg)
+                _set_state(state="error", last_error=msg, last_check=_now_iso())
                 return False
 
             tldirlist = []
@@ -257,7 +321,9 @@ def main():
                 ftp.retrlines('LIST', tltndirlist.append)
                 tltndirlist = [parse_ftp_listing(line) for line in tltndirlist if parse_ftp_listing(line)]
             except all_errors as ex:
-                print(f"FTP error during directory listing: {ex}")
+                msg = f"FTP error during directory listing: {ex}"
+                print(msg)
+                _set_state(state="error", last_error=msg, last_check=_now_iso())
                 return False
 
             tldirlist_dict = {get_base_name(item['name']): item for item in tldirlist}
@@ -266,6 +332,7 @@ def main():
 
             if not matching_files:
                 print('No matching files found.')
+                _set_state(state="idle", current_file=None, last_check=_now_iso(), last_success=_now_iso())
                 return False
 
             matching_files.sort(key=lambda x: parse_date(x) or datetime.min, reverse=True)
@@ -279,6 +346,7 @@ def main():
 
             for item in files_to_download:
                 print(f'Processing: {item["name"]}')
+                _set_state(current_file=item["name"])
                 should_delete_remote_file = True
                 local_filename = os.path.join(out_dir, item["name"])
                 file_size = item["size"]
@@ -440,8 +508,12 @@ def main():
             if total_pbar:
                 total_pbar.close()
 
+            _set_state(state="idle", current_file=None, last_check=_now_iso(), last_success=_now_iso())
+
         except Exception as ex:
-            print(f"General error in download_and_process: {ex}")
+            msg = f"General error in download_and_process: {ex}"
+            print(msg)
+            _set_state(state="error", current_file=None, last_error=msg, last_check=_now_iso())
             return False
         finally:
             if ftp is not None:

--- a/get_timelapse.py
+++ b/get_timelapse.py
@@ -392,6 +392,15 @@ def main():
                         print(f'Running ffmpeg to create streamable: {streamable_filename}')
                         subprocess.run(ffmpeg_cmd, check=True)
                         print(f'Streamable file created: {streamable_filename}')
+                        # Match the README's "deletes original files after successful
+                        # conversion" promise — drop the source .avi as soon as the
+                        # encoded .mp4 exists, so users without Telegram configured
+                        # don't keep ~3x disk per timelapse.
+                        try:
+                            os.remove(local_filename)
+                            print(f'Original deleted after encode: {local_filename}')
+                        except OSError as e:
+                            print(f'Could not delete original {local_filename}: {e}')
                         max_telegram_size = 49 * 1024 * 1024  # 49 MB
                         file_size = os.path.getsize(streamable_filename)
                         if file_size > max_telegram_size:


### PR DESCRIPTION
Two small, independent changes that surfaced from running this in a self-hosted setup. Happy to split into two PRs if you prefer — each commit is self-contained.

## 1. Delete original `.avi` after successful encode

The README states the script *"deletes original files after successful conversion"*, but the existing deletion only runs after a successful Telegram upload. Users without Telegram configured (or with uploads failing for unrelated reasons) accumulate the source `.avi` alongside the streamable `.mp4`, paying ~3× disk per timelapse.

Moves the source `os.remove(local_filename)` to immediately after the successful `ffmpeg` run, which matches the documented behavior. The later Telegram-cleanup block still removes the `.mp4` if it was uploaded; only the source file's lifetime changed.

## 2. Optional `--status-port` HTTP endpoint

When running in `--watch` mode this script is a long-lived daemon, but there's no way for an external monitor to tell whether it's healthy. Just checking the container's PID misses the common *"printer FTPS daemon hung; watcher is connect-timing-out every minute"* failure mode.

Adds an optional stdlib-only HTTP status server, **off by default**, opt-in via `--status-port PORT`. Returns JSON:

```json
{
  "state": "idle",
  "last_check": "2026-05-18T13:11:12",
  "last_success": "2026-05-18T13:11:12",
  "last_error": null,
  "current_file": null
}
```

`state` is one of `starting | idle | working | error`. HTTP status code is **200** normally and **503** when the last cycle errored, so a plain status-code monitor (e.g., Uptime Kuma HTTP(s)) is sufficient — no JSON parsing required on the monitor side.

The watch loop and download/encode paths set the state at key transitions. No new dependencies (stdlib `http.server` + `threading`). README updated with the new option.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('get_timelapse.py').read())"` — parses
- [x] Manually exercised `--watch --status-port 8000` against a Bambu P1S: state transitions through `working` → `idle` correctly; goes to `error` (HTTP 503) when the printer's FTPS daemon hangs; clears on next successful cycle
- [x] `.avi` deletion confirmed against a backlog of 8 prints
